### PR TITLE
Add Google Analytics to Data Playbook

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,6 @@ version:          3.0 | November 2018
 
 github:
   repo:           https://github.com/CHHSData/DataPlaybook
+
+# Google Analytics
+google_analytics: UA-56144207-2

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,4 +21,10 @@
 
   <!-- Favicon -->
   <link rel="shortcut icon" href="{{ site.baseurl }}/assets/favicon.ico">
+  
+  <!-- Google Analytics -->
+  {% if site.google_analytics and jekyll.environment == 'production' %}
+  {% include analytics.html %}
+  {% endif %}
+  
 </head>


### PR DESCRIPTION
This PR includes one new page and two updates to config files. The result is that the Google analytics page will be added asynchronously to the `<head>` tag in all site pages. This async code supports older IE browsers, which are commonly used by government depts who are slow to upgrade to a modern Chrome or Firefox browser.

Details about how this change works can be found at https://desiredpersona.com/google-analytics-jekyll/