### PR TITLE
Fix Double Slash in Navigation Menu

### DIFF
--- a/2_assess.md
+++ b/2_assess.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: 2. Assess
-permalink: assess
+permalink: /assess/
 ---
 ## Play 02. Assess: tools & capabilities
 

--- a/2_assess.md
+++ b/2_assess.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: 2. Assess
-permalink: /assess/
+permalink: assess
 ---
 ## Play 02. Assess: tools & capabilities
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -20,7 +20,7 @@
     {% for node in pages_list %}
       {% if node.title != null %}
         {% if node.layout == "page" %}
-          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.baseurl }}/{{ node.url }}">{{ node.title }}</a>
+          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
         {% endif %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
This change removes a "/" from the URL that is generated for the site navigation menu that is visible on all site pages. This slash was causing a double-slash in the URL the user navigated to, which causes problems with Google Analytics page view counts.